### PR TITLE
Fix Typescript definitions

### DIFF
--- a/typings/rfetch.d.ts
+++ b/typings/rfetch.d.ts
@@ -47,4 +47,4 @@ export interface RetryOptions {
   context?: RetryOptionsContext;
 }
 
-export default function rfetch(url: string, options: Object | null, retryOptions: RetryOptions | null): Promise<any>;
+export default function rfetch(url: RequestInfo, options?: RequestInit, retryOptions?: RetryOptions): Promise<Response>;

--- a/typings/rfetch.d.ts
+++ b/typings/rfetch.d.ts
@@ -47,4 +47,4 @@ export interface RetryOptions {
   context?: RetryOptionsContext;
 }
 
-export function rfetch(url: string, options: Object | null, retryOptions: RetryOptions | null): Promise<any>;
+export default function rfetch(url: string, options: Object | null, retryOptions: RetryOptions | null): Promise<any>;


### PR DESCRIPTION
This fixes a couple of Typescript erros:
* Correct export of `rfetch()`
* Make 2nd and 3rd parameter of `rfetch()` optional

It also improves the type safety of the 1st and 2nd argument and also the returned Promise.